### PR TITLE
Formal definition (SKOS in JSON-LD) of technology readiness levels for research

### DIFF
--- a/schemas/research-technology-readiness-level.jsonld
+++ b/schemas/research-technology-readiness-level.jsonld
@@ -3,25 +3,13 @@
         "trl": "https://w3id.org/research-technology-readiness-level#",
         "skos": "http://www.w3.org/2004/02/skos/core#",
         "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
-        "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
-        "prefLabel": { "@id": "skos:prefLabel" },
-        "Concept": { "@id": "skos:Concept" },
-        "definition": { "@id": "skos:definition" },
-        "notation": { "@id": "skos:notation" },
-        "inScheme": { "@id": "skos:inScheme" },
-        "Property": { "@id": "rdf:Property" },
-        "label": { "@id": "rdfs:label" },
-        "comment": { "@id": "rdfs:comment" },
-        "Property": { "@id": "rdf:Property" },
-        "OrderedCollection": { "@id": "skos:OrderedCollection" },
-        "ConceptScheme": { "@id": "skos:ConceptScheme" },
-        "memberList": { "@id": "skos:memberList" }
+        "rdfs": "http://www.w3.org/2000/01/rdf-schema#"
     },
     "@graph": [
         {
             "@id": "trl:Levels",
-            "@type": "OrderedCollection",
-            "memberList": [
+            "@type": "skos:OrderedCollection",
+            "skos:memberList": [
                 "tlr:Level0Idea",
                 "tlr:Level1InitialResearch",
                 "tlr:Level2ConceptFormulated",
@@ -36,93 +24,93 @@
         },
         {
             "@id": "tlr:Scheme",
-            "@type": "ConceptScheme"
+            "@type": "skos:ConceptScheme"
         },
         {
             "@id": "trl:Level0Idea",
-            "@type": "Concept",
-            "inScheme": "tlr:Scheme",
-            "prefLabel": "0 - Idea",
-            "notation": "0",
-            "definition": "Unproven, untested and largely unformulated concept"
+            "@type": "skos:Concept",
+            "skos:inScheme": "tlr:Scheme",
+            "skos:prefLabel": "0 - Idea",
+            "skos:notation": "0",
+            "skos:definition": "Unproven, untested and largely unformulated concept"
         },
         {
             "@id": "trl:Level1InitialResearch",
-            "@type": "Concept",
-            "inScheme": "tlr:Scheme",
-            "prefLabel": "1 - Initial Research",
-            "notation": "1",
-            "definition": "Basic (scholarly) needs observed and reported"
+            "@type": "skos:Concept",
+            "skos:inScheme": "tlr:Scheme",
+            "skos:prefLabel": "1 - Initial Research",
+            "skos:notation": "1",
+            "skos:definition": "Basic (scholarly) needs observed and reported"
         },
         {
             "@id": "trl:Level2ConceptFormulated",
-            "@type": "Concept",
-            "inScheme": "tlr:Scheme",
-            "prefLabel": "2 - Concept Formulated",
-            "notation": "2",
-            "definition": "Initial technology/application has seen concept formulated"
+            "@type": "skos:Concept",
+            "skos:inScheme": "tlr:Scheme",
+            "skos:prefLabel": "2 - Concept Formulated",
+            "skos:notation": "2",
+            "skos:definition": "Initial technology/application has seen concept formulated"
         },
         {
             "@id": "trl:Level3ProofOfConcept",
-            "@type": "Concept",
-            "inScheme": "tlr:Scheme",
-            "prefLabel": "3 - Proof of Concept",
-            "notation": "3",
-            "definition": "Initial Proof-of-concept of key functionality. Concept presented for initial feedback from scholarly users. Not yet validated and not suitable for end-users yet."
+            "@type": "skos:Concept",
+            "skos:inScheme": "tlr:Scheme",
+            "skos:prefLabel": "3 - Proof of Concept",
+            "skos:notation": "3",
+            "skos:definition": "Initial Proof-of-concept of key functionality. Concept presented for initial feedback from scholarly users. Not yet validated and not suitable for end-users yet."
         },
         {
             "@id": "trl:Level4ValidatedProofOfConcept",
-            "@type": "Concept",
-            "inScheme": "tlr:Scheme",
-            "prefLabel": "4 - Validated Proof of Concept",
-            "notation": "4",
-            "definition": "Validated Proof-of-concept of key functionality. Technology validated in its own experimental setting (e.g. the lab). Not mature enough for end-users yet."
+            "@type": "skos:Concept",
+            "skos:inScheme": "tlr:Scheme",
+            "skos:prefLabel": "4 - Validated Proof of Concept",
+            "skos:notation": "4",
+            "skos:definition": "Validated Proof-of-concept of key functionality. Technology validated in its own experimental setting (e.g. the lab). Not mature enough for end-users yet."
         },
         {
             "@id": "trl:Level5EarlyPrototype",
-            "@type": "Concept",
-            "inScheme": "tlr:Scheme",
-            "prefLabel": "5 - Early Prototype",
-            "notation": "5",
-            "definition": "Technology validated in target setting (e.g. with potential end-users)"
+            "@type": "skos:Concept",
+            "skos:inScheme": "tlr:Scheme",
+            "skos:prefLabel": "5 - Early Prototype",
+            "skos:notation": "5",
+            "skos:definition": "Technology validated in target setting (e.g. with potential end-users)"
         },
         {
             "@id": "trl:Level6LatePrototype",
-            "@type": "Concept",
-            "inScheme": "tlr:Scheme",
-            "prefLabel": "6 - Late prototype",
-            "notation": "6",
-            "definition": "Technology demonstrated in target setting, end-users adopt it for testing purposes."
+            "@type": "skos:Concept",
+            "skos:inScheme": "tlr:Scheme",
+            "skos:prefLabel": "6 - Late prototype",
+            "skos:notation": "6",
+            "skos:definition": "Technology demonstrated in target setting, end-users adopt it for testing purposes."
         },
         {
             "@id": "trl:Level7ReleaseCandidate",
-            "@type": "Concept",
-            "inScheme": "tlr:Scheme",
-            "prefLabel": "7 - Release Candidate",
-            "notation": "7",
-            "definition": "Technology ready enough and in initial use by end-users in intended scholarly environments. Further validation may be in progress."
+            "@type": "skos:Concept",
+            "skos:inScheme": "tlr:Scheme",
+            "skos:prefLabel": "7 - Release Candidate",
+            "skos:notation": "7",
+            "skos:definition": "Technology ready enough and in initial use by end-users in intended scholarly environments. Further validation may be in progress."
         },
         {
             "@id": "trl:Level8Complete",
-            "@type": "Concept",
-            "inScheme": "tlr:Scheme",
-            "prefLabel": "8 - Complete",
-            "notation": "8",
-            "definition": "Technology complete and qualified, released for all end-users in scholarly environments."
+            "@type": "skos:Concept",
+            "skos:inScheme": "tlr:Scheme",
+            "skos:prefLabel": "8 - Complete",
+            "skos:notation": "8",
+            "skos:definition": "Technology complete and qualified, released for all end-users in scholarly environments."
         },
         {
             "@id": "trl:Level9Proven",
-            "@type": "Concept",
-            "inScheme": "tlr:Scheme",
-            "prefLabel": "9 - Proven",
-            "notation": "9",
-            "definition": "Technology complete and proven in practice by real users."
+            "@type": "skos:Concept",
+            "skos:inScheme": "tlr:Scheme",
+            "skos:prefLabel": "9 - Proven",
+            "skos:notation": "9",
+            "skos:definition": "Technology complete and proven in practice by real users."
         },
         {
             "@id": "tlr:technologyReadinessLevel",
-            "@type": "Property",
-            "label": "Technology Readiness Level",
-            "comment": "Associates a technology readiness level with a subject (e.g. schema:SoftwareSourceCode or schema:SoftwareApplication). Takes a value (skos:Concept) from collection tlr:Levels (in conceptscheme tlr:Scheme)"
+            "@type": "rdf:Property",
+            "rdfs:label": "Technology Readiness Level",
+            "rdfs:comment": "Associates a technology readiness level with a subject (e.g. schema:SoftwareSourceCode or schema:SoftwareApplication). Takes a value (skos:Concept) from collection tlr:Levels (in conceptscheme tlr:Scheme)"
         }
     ]
 }

--- a/schemas/research-technology-readiness-level.jsonld
+++ b/schemas/research-technology-readiness-level.jsonld
@@ -1,0 +1,128 @@
+{
+    "@context": {
+        "trl": "https://w3id.org/research-technology-readiness-level#",
+        "skos": "http://www.w3.org/2004/02/skos/core#",
+        "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+        "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+        "prefLabel": { "@id": "skos:prefLabel" },
+        "Concept": { "@id": "skos:Concept" },
+        "definition": { "@id": "skos:definition" },
+        "notation": { "@id": "skos:notation" },
+        "inScheme": { "@id": "skos:inScheme" },
+        "Property": { "@id": "rdf:Property" },
+        "label": { "@id": "rdfs:label" },
+        "comment": { "@id": "rdfs:comment" },
+        "Property": { "@id": "rdf:Property" },
+        "OrderedCollection": { "@id": "skos:OrderedCollection" },
+        "ConceptScheme": { "@id": "skos:ConceptScheme" },
+        "memberList": { "@id": "skos:memberList" }
+    },
+    "@graph": [
+        {
+            "@id": "trl:Levels",
+            "@type": "OrderedCollection",
+            "memberList": [
+                "tlr:Level0Idea",
+                "tlr:Level1InitialResearch",
+                "tlr:Level2ConceptFormulated",
+                "tlr:Level3ProofOfConcept",
+                "trl:Level4ValidatedProofOfConcept",
+                "trl:Level5EarlyPrototype",
+                "trl:Level6LatePrototype",
+                "trl:Level7ReleaseCandidate",
+                "trl:Level8Complete",
+                "trl:Level9Proven"
+            ]
+        },
+        {
+            "@id": "tlr:Scheme",
+            "@type": "ConceptScheme"
+        },
+        {
+            "@id": "trl:Level0Idea",
+            "@type": "Concept",
+            "inScheme": "tlr:Scheme",
+            "prefLabel": "0 - Idea",
+            "notation": "0",
+            "definition": "Unproven, untested and largely unformulated concept"
+        },
+        {
+            "@id": "trl:Level1InitialResearch",
+            "@type": "Concept",
+            "inScheme": "tlr:Scheme",
+            "prefLabel": "1 - Initial Research",
+            "notation": "1",
+            "definition": "Basic (scholarly) needs observed and reported"
+        },
+        {
+            "@id": "trl:Level2ConceptFormulated",
+            "@type": "Concept",
+            "inScheme": "tlr:Scheme",
+            "prefLabel": "2 - Concept Formulated",
+            "notation": "2",
+            "definition": "Initial technology/application has seen concept formulated"
+        },
+        {
+            "@id": "trl:Level3ProofOfConcept",
+            "@type": "Concept",
+            "inScheme": "tlr:Scheme",
+            "prefLabel": "3 - Proof of Concept",
+            "notation": "3",
+            "definition": "Initial Proof-of-concept of key functionality. Concept presented for initial feedback from scholarly users. Not yet validated and not suitable for end-users yet."
+        },
+        {
+            "@id": "trl:Level4ValidatedProofOfConcept",
+            "@type": "Concept",
+            "inScheme": "tlr:Scheme",
+            "prefLabel": "4 - Validated Proof of Concept",
+            "notation": "4",
+            "definition": "Validated Proof-of-concept of key functionality. Technology validated in its own experimental setting (e.g. the lab). Not mature enough for end-users yet."
+        },
+        {
+            "@id": "trl:Level5EarlyPrototype",
+            "@type": "Concept",
+            "inScheme": "tlr:Scheme",
+            "prefLabel": "5 - Early Prototype",
+            "notation": "5",
+            "definition": "Technology validated in target setting (e.g. with potential end-users)"
+        },
+        {
+            "@id": "trl:Level6LatePrototype",
+            "@type": "Concept",
+            "inScheme": "tlr:Scheme",
+            "prefLabel": "6 - Late prototype",
+            "notation": "6",
+            "definition": "Technology demonstrated in target setting, end-users adopt it for testing purposes."
+        },
+        {
+            "@id": "trl:Level7ReleaseCandidate",
+            "@type": "Concept",
+            "inScheme": "tlr:Scheme",
+            "prefLabel": "7 - Release Candidate",
+            "notation": "7",
+            "definition": "Technology ready enough and in initial use by end-users in intended scholarly environments. Further validation may be in progress."
+        },
+        {
+            "@id": "trl:Level8Complete",
+            "@type": "Concept",
+            "inScheme": "tlr:Scheme",
+            "prefLabel": "8 - Complete",
+            "notation": "8",
+            "definition": "Technology complete and qualified, released for all end-users in scholarly environments."
+        },
+        {
+            "@id": "trl:Level9Proven",
+            "@type": "Concept",
+            "inScheme": "tlr:Scheme",
+            "prefLabel": "9 - Proven",
+            "notation": "9",
+            "definition": "Technology complete and proven in practice by real users."
+        },
+        {
+            "@id": "tlr:technologyReadinessLevel",
+            "@type": "Property",
+            "label": "Technology Readiness Level",
+            "comment": "Associates a technology readiness level with a subject (e.g. schema:SoftwareSourceCode or schema:SoftwareApplication). Takes a value (skos:Concept) from collection tlr:Levels (in conceptscheme tlr:Scheme)"
+        }
+    ]
+}

--- a/schemas/research-technology-readiness-level.jsonld
+++ b/schemas/research-technology-readiness-level.jsonld
@@ -27,8 +27,12 @@
             "@type": "skos:ConceptScheme"
         },
         {
+            "@id": "tlr:TechnologyReadinessLevel",
+            "@type": "rdfs:Class"
+        },
+        {
             "@id": "trl:Level0Idea",
-            "@type": "skos:Concept",
+            "@type": [ "skos:Concept", "tlr:TechnologyReadinessLevel" ],
             "skos:inScheme": "tlr:Scheme",
             "skos:prefLabel": "0 - Idea",
             "skos:notation": "0",
@@ -36,7 +40,7 @@
         },
         {
             "@id": "trl:Level1InitialResearch",
-            "@type": "skos:Concept",
+            "@type": [ "skos:Concept", "tlr:TechnologyReadinessLevel" ],
             "skos:inScheme": "tlr:Scheme",
             "skos:prefLabel": "1 - Initial Research",
             "skos:notation": "1",
@@ -44,7 +48,7 @@
         },
         {
             "@id": "trl:Level2ConceptFormulated",
-            "@type": "skos:Concept",
+            "@type": [ "skos:Concept", "tlr:TechnologyReadinessLevel" ],
             "skos:inScheme": "tlr:Scheme",
             "skos:prefLabel": "2 - Concept Formulated",
             "skos:notation": "2",
@@ -52,7 +56,7 @@
         },
         {
             "@id": "trl:Level3ProofOfConcept",
-            "@type": "skos:Concept",
+            "@type": [ "skos:Concept", "tlr:TechnologyReadinessLevel" ],
             "skos:inScheme": "tlr:Scheme",
             "skos:prefLabel": "3 - Proof of Concept",
             "skos:notation": "3",
@@ -60,7 +64,7 @@
         },
         {
             "@id": "trl:Level4ValidatedProofOfConcept",
-            "@type": "skos:Concept",
+            "@type": [ "skos:Concept", "tlr:TechnologyReadinessLevel" ],
             "skos:inScheme": "tlr:Scheme",
             "skos:prefLabel": "4 - Validated Proof of Concept",
             "skos:notation": "4",
@@ -68,7 +72,7 @@
         },
         {
             "@id": "trl:Level5EarlyPrototype",
-            "@type": "skos:Concept",
+            "@type": [ "skos:Concept", "tlr:TechnologyReadinessLevel" ],
             "skos:inScheme": "tlr:Scheme",
             "skos:prefLabel": "5 - Early Prototype",
             "skos:notation": "5",
@@ -76,7 +80,7 @@
         },
         {
             "@id": "trl:Level6LatePrototype",
-            "@type": "skos:Concept",
+            "@type": [ "skos:Concept", "tlr:TechnologyReadinessLevel" ],
             "skos:inScheme": "tlr:Scheme",
             "skos:prefLabel": "6 - Late prototype",
             "skos:notation": "6",
@@ -84,7 +88,7 @@
         },
         {
             "@id": "trl:Level7ReleaseCandidate",
-            "@type": "skos:Concept",
+            "@type": [ "skos:Concept", "tlr:TechnologyReadinessLevel" ],
             "skos:inScheme": "tlr:Scheme",
             "skos:prefLabel": "7 - Release Candidate",
             "skos:notation": "7",
@@ -92,7 +96,7 @@
         },
         {
             "@id": "trl:Level8Complete",
-            "@type": "skos:Concept",
+            "@type": [ "skos:Concept", "tlr:TechnologyReadinessLevel" ],
             "skos:inScheme": "tlr:Scheme",
             "skos:prefLabel": "8 - Complete",
             "skos:notation": "8",
@@ -100,7 +104,7 @@
         },
         {
             "@id": "trl:Level9Proven",
-            "@type": "skos:Concept",
+            "@type": [ "skos:Concept", "tlr:TechnologyReadinessLevel" ],
             "skos:inScheme": "tlr:Scheme",
             "skos:prefLabel": "9 - Proven",
             "skos:notation": "9",
@@ -110,7 +114,8 @@
             "@id": "tlr:technologyReadinessLevel",
             "@type": "rdf:Property",
             "rdfs:label": "Technology Readiness Level",
-            "rdfs:comment": "Associates a technology readiness level with a subject (e.g. schema:SoftwareSourceCode or schema:SoftwareApplication). Takes a value (skos:Concept) from collection tlr:Levels (in conceptscheme tlr:Scheme)"
+            "rdfs:comment": "Associates a technology readiness level with a subject (e.g. schema:SoftwareSourceCode or schema:SoftwareApplication). Takes a value (skos:Concept) from collection tlr:Levels (in conceptscheme tlr:Scheme)",
+            "rdfs:range": "tlr:TechnologyReadinessLevel" 
         }
     ]
 }

--- a/schemas/research-technology-readiness-level.jsonld
+++ b/schemas/research-technology-readiness-level.jsonld
@@ -10,6 +10,10 @@
             "@id": "trl:Levels",
             "@type": "skos:OrderedCollection",
             "skos:memberList": [
+                "tlr:Stage1Planning",
+                "tlr:Stage2ProofOfConcept",
+                "tlr:Stage3Experimental",
+                "tlr:Stage4Complete",
                 "tlr:Level0Idea",
                 "tlr:Level1InitialResearch",
                 "tlr:Level2ConceptFormulated",
@@ -23,6 +27,16 @@
             ]
         },
         {
+            "@id": "trl:Stages",
+            "@type": "skos:OrderedCollection",
+            "skos:memberList": [
+                "tlr:Stage1Planning",
+                "tlr:Stage2ProofOfConcept",
+                "tlr:Stage3Experimental",
+                "tlr:Stage4Complete"
+            ]
+        },
+        {
             "@id": "tlr:Scheme",
             "@type": "skos:ConceptScheme"
         },
@@ -31,12 +45,49 @@
             "@type": "rdfs:Class"
         },
         {
+            "@id": "trl:Stage1Planning",
+            "@type": [ "skos:Concept", "tlr:TechnologyReadinessLevel" ],
+            "skos:inScheme": "tlr:Scheme",
+            "skos:prefLabel": "Planning",
+            "skos:altLabel": "pre-alpha",
+            "skos:notation": "0-2",
+            "skos:definition": "The technology is in an initial planning stage (pre-alpha), no implementation is available yet"
+        },
+        {
+            "@id": "trl:Stage2ProofOfConcept",
+            "@type": [ "skos:Concept", "tlr:TechnologyReadinessLevel" ],
+            "skos:inScheme": "tlr:Scheme",
+            "skos:prefLabel": "Proof of Concept",
+            "skos:altLabel": "alpha",
+            "skos:notation": "3-4",
+            "skos:definition": "An initial proof-of-concept implementation of the technology is available (alpha). It is not mature enough for end-users yet."
+        },
+        {
+            "@id": "trl:Stage3Experimental",
+            "@type": [ "skos:Concept", "tlr:TechnologyReadinessLevel" ],
+            "skos:inScheme": "tlr:Scheme",
+            "skos:prefLabel": "Experimental",
+            "skos:altLabel": "beta",
+            "skos:notation": "5-7",
+            "skos:definition": "The technology is implemented and ready for experimental settings (beta), but requires further work and validation."
+        },
+        {
+            "@id": "trl:Stage4Complete",
+            "@type": [ "skos:Concept", "tlr:TechnologyReadinessLevel" ],
+            "skos:inScheme": "tlr:Scheme",
+            "skos:prefLabel": "Complete",
+            "skos:altLabel": "stable",
+            "skos:notation": "8-9",
+            "skos:definition": "The technology is complete, stable and deployed in production scenarios for end-users"
+        },
+        {
             "@id": "trl:Level0Idea",
             "@type": [ "skos:Concept", "tlr:TechnologyReadinessLevel" ],
             "skos:inScheme": "tlr:Scheme",
             "skos:prefLabel": "0 - Idea",
             "skos:notation": "0",
-            "skos:definition": "Unproven, untested and largely unformulated concept"
+            "skos:definition": "Unproven, untested and largely unformulated concept",
+            "skos:broader": "trl:Stage1Planning"
         },
         {
             "@id": "trl:Level1InitialResearch",
@@ -44,7 +95,8 @@
             "skos:inScheme": "tlr:Scheme",
             "skos:prefLabel": "1 - Initial Research",
             "skos:notation": "1",
-            "skos:definition": "Basic (scholarly) needs observed and reported"
+            "skos:definition": "Basic (scholarly) needs observed and reported",
+            "skos:broader": "trl:Stage1Planning"
         },
         {
             "@id": "trl:Level2ConceptFormulated",
@@ -52,7 +104,8 @@
             "skos:inScheme": "tlr:Scheme",
             "skos:prefLabel": "2 - Concept Formulated",
             "skos:notation": "2",
-            "skos:definition": "Initial technology/application has seen concept formulated"
+            "skos:definition": "Initial technology/application has seen concept formulated",
+            "skos:broader": "trl:Stage1Planning"
         },
         {
             "@id": "trl:Level3ProofOfConcept",
@@ -60,7 +113,8 @@
             "skos:inScheme": "tlr:Scheme",
             "skos:prefLabel": "3 - Proof of Concept",
             "skos:notation": "3",
-            "skos:definition": "Initial Proof-of-concept of key functionality. Concept presented for initial feedback from scholarly users. Not yet validated and not suitable for end-users yet."
+            "skos:definition": "Initial Proof-of-concept of key functionality. Concept presented for initial feedback from scholarly users. Not yet validated and not suitable for end-users yet.",
+            "skos:broader": "trl:Stage2ProofOfConcept"
         },
         {
             "@id": "trl:Level4ValidatedProofOfConcept",
@@ -68,7 +122,8 @@
             "skos:inScheme": "tlr:Scheme",
             "skos:prefLabel": "4 - Validated Proof of Concept",
             "skos:notation": "4",
-            "skos:definition": "Validated Proof-of-concept of key functionality. Technology validated in its own experimental setting (e.g. the lab). Not mature enough for end-users yet."
+            "skos:definition": "Validated Proof-of-concept of key functionality. Technology validated in its own experimental setting (e.g. the lab). Not mature enough for end-users yet.",
+            "skos:broader": "trl:Stage2ProofOfConcept"
         },
         {
             "@id": "trl:Level5EarlyPrototype",
@@ -76,7 +131,8 @@
             "skos:inScheme": "tlr:Scheme",
             "skos:prefLabel": "5 - Early Prototype",
             "skos:notation": "5",
-            "skos:definition": "Technology validated in target setting (e.g. with potential end-users)"
+            "skos:definition": "Technology validated in target setting (e.g. with potential end-users)",
+            "skos:broader": "trl:Stage3Experimental"
         },
         {
             "@id": "trl:Level6LatePrototype",
@@ -84,7 +140,8 @@
             "skos:inScheme": "tlr:Scheme",
             "skos:prefLabel": "6 - Late prototype",
             "skos:notation": "6",
-            "skos:definition": "Technology demonstrated in target setting, end-users adopt it for testing purposes."
+            "skos:definition": "Technology demonstrated in target setting, end-users adopt it for testing purposes.",
+            "skos:broader": "trl:Stage3Experimental"
         },
         {
             "@id": "trl:Level7ReleaseCandidate",
@@ -92,7 +149,8 @@
             "skos:inScheme": "tlr:Scheme",
             "skos:prefLabel": "7 - Release Candidate",
             "skos:notation": "7",
-            "skos:definition": "Technology ready enough and in initial use by end-users in intended scholarly environments. Further validation may be in progress."
+            "skos:definition": "Technology ready enough and in initial use by end-users in intended scholarly environments. Further validation may be in progress.",
+            "skos:broader": "trl:Stage3Experimental"
         },
         {
             "@id": "trl:Level8Complete",
@@ -100,7 +158,8 @@
             "skos:inScheme": "tlr:Scheme",
             "skos:prefLabel": "8 - Complete",
             "skos:notation": "8",
-            "skos:definition": "Technology complete and qualified, released for all end-users in scholarly environments."
+            "skos:definition": "Technology complete and qualified, released for all end-users in scholarly environments.",
+            "skos:broader": "trl:Stage4Complete"
         },
         {
             "@id": "trl:Level9Proven",
@@ -108,13 +167,14 @@
             "skos:inScheme": "tlr:Scheme",
             "skos:prefLabel": "9 - Proven",
             "skos:notation": "9",
-            "skos:definition": "Technology complete and proven in practice by real users."
+            "skos:definition": "Technology complete and proven in practice by real users.",
+            "skos:broader": "trl:Stage4Complete"
         },
         {
             "@id": "tlr:technologyReadinessLevel",
             "@type": "rdf:Property",
             "rdfs:label": "Technology Readiness Level",
-            "rdfs:comment": "Associates a technology readiness level with a subject (e.g. schema:SoftwareSourceCode or schema:SoftwareApplication). Takes a value (skos:Concept) from collection tlr:Levels (in conceptscheme tlr:Scheme)",
+            "rdfs:comment": "Associates a technology readiness level (or a stage grouping several levels) with a subject (e.g. schema:SoftwareSourceCode or schema:SoftwareApplication). Takes a value (skos:Concept) from collection tlr:Levels (in conceptscheme tlr:Scheme)",
             "rdfs:range": "tlr:TechnologyReadinessLevel" 
         }
     ]


### PR DESCRIPTION
This definition formalizes the technology readiness levels we drafted for the Shared Development Roadmap and follows earlier discussion in CLARIAH/clariah-plus#98 .

Although initially meant for tool discovery, I've kept the definitions generic, it mentions 'technology' and not 'software' in particular.

Do we agree on the levels and the definitions? Are they clear enough as they are?