### PR TITLE
Add vocabulary recommender search UI

### DIFF
--- a/source-registry/vocabulary-recommender-search-ui.yml
+++ b/source-registry/vocabulary-recommender-search-ui.yml
@@ -1,0 +1,1 @@
+source: https://github.com/CLARIAH/search-UI


### PR DESCRIPTION
The tool is currently online here: https://static.triply.cc/vocabulary-recommender, and needs to be moved to the CLARIAH infrastructure (this is why I haven't included is as a service). 