### PR TITLE
Remove mediasuite apis

### DIFF
--- a/source-registry/labo-components.yml
+++ b/source-registry/labo-components.yml
@@ -1,2 +1,0 @@
-source: https://github.com/CLARIAH/labo-components
-group: Media Suite

--- a/source-registry/labo-workspace-components.yml
+++ b/source-registry/labo-workspace-components.yml
@@ -1,2 +1,0 @@
-source: https://github.com/beeldengeluid/labo-workspace-components
-group: Media Suite

--- a/source-registry/labs-annotation-api.yml
+++ b/source-registry/labs-annotation-api.yml
@@ -1,2 +1,0 @@
-source: https://github.com/CLARIAH/labs-annotation-api
-group: Media Suite

--- a/source-registry/labs-playout-proxy.yml
+++ b/source-registry/labs-playout-proxy.yml
@@ -1,2 +1,0 @@
-source: https://github.com/CLARIAH/labs-playout-proxy
-group: Media Suite

--- a/source-registry/labs-search-api.yml
+++ b/source-registry/labs-search-api.yml
@@ -1,2 +1,0 @@
-source: https://github.com/CLARIAH/labs-search-api
-group: Media Suite

--- a/source-registry/labs-user-space-api.yml
+++ b/source-registry/labs-user-space-api.yml
@@ -1,2 +1,0 @@
-source: https://github.com/CLARIAH/labs-user-space-api
-group: Media Suite


### PR DESCRIPTION
These repos are not reusable so they are not suitable for the tools registry