### PR TITLE
add MUSic-related Citizen Science Listening Experiments

### DIFF
--- a/source-registry/muscle.yml
+++ b/source-registry/muscle.yml
@@ -1,0 +1,3 @@
+source: https://github.com/Amsterdam-Music-Lab/MUSCLE
+services: 
+  - https://app.amsterdammusiclab.nl/


### PR DESCRIPTION
This PR adds a reference to MUSCLE, an infrastructure to build online experiments with audio stimuli.