### PR TITLE
IvdNT GitHub org rename. Update old links.

### DIFF
--- a/legacy/cmdi/ANW.cmdi.xml
+++ b/legacy/cmdi/ANW.cmdi.xml
@@ -32,7 +32,7 @@
             <title xml:lang="nld">Algemeen Nederlands Woordenboek</title>
             <title xml:lang="eng">General Dutch Dictionary</title>
             <publicationYear>2009</publicationYear>
-            <url>http://anw.ivdnt.org</url><CLARINCentre>Dutch Language Institute</CLARINCentre>
+            <url>https://anw.ivdnt.org</url><CLARINCentre>Dutch Language Institute</CLARINCentre>
             <ReleaseStatus>
                <LifeCycleStatus>published</LifeCycleStatus>
                <lastUpdate>2016-01-01</lastUpdate>
@@ -122,7 +122,7 @@
                <license>unknown</license>
                <distributionType>public</distributionType>
 	       <availability/>
-               <url>http://anw.ivdnt.org</url>
+               <url>https://anw.ivdnt.org</url>
                <Price>
                   <amount>0</amount>
                   <ISO4217>
@@ -134,16 +134,16 @@
                <Email>servicedesk@ivdnt.org</Email>
                <Organisation xml:lang="nld">Instituut voor de Nederlandse Taal</Organisation>
                <Organisation xml:lang="eng">Institute for the Dutch Language</Organisation>
-               <Url>http://www.ivdnt.org/</Url>
+               <Url>https://www.ivdnt.org/</Url>
             </Contact>
          </Access>
          <ResourceDocumentation>
             <Documentation>
                <title>Frequently Asked Questions</title>
                <documentationTarget>user</documentationTarget>
-               <url>http://anw.ivdnt.org/about</url>
+               <url>https://anw.ivdnt.org/about</url>
                <ISO639>
-                  <iso-639-3-code>ndl</iso-639-3-code>
+                  <iso-639-3-code>nld</iso-639-3-code>
                </ISO639>
             </Documentation>
          </ResourceDocumentation>
@@ -152,12 +152,12 @@
                <name>ANW</name>
                <title>Algemeen Nederlands Woordenboek</title>
                <funder>IVDNT.ORG</funder>
-               <url>http://ivdnt.org</url>
+               <url>https://ivdnt.org</url>
                <Contact>
                   <Email>servicedesk@ivdnt.org</Email>
 		  <Organisation xml:lang="nld">Instituut voor de Nederlandse Taal</Organisation>
 		  <Organisation xml:lang="eng">Institute for the Dutch Language</Organisation>
-		  <Url>http://www.ivdnt.org/</Url>
+		  <Url>https://www.ivdnt.org/</Url>
                </Contact>
                <Duration/>
             </Project>
@@ -167,7 +167,7 @@
                   <Email>carole.tiberius@ivdnt.org</Email>
 		  <Organisation xml:lang="nld">Instituut voor de Nederlandse Taal</Organisation>
 		  <Organisation xml:lang="eng">Institute for the Dutch Language</Organisation>
-		  <Url>http://www.ivdnt.org/over-ons/contact/medewerkers</Url>
+		  <Url>https://www.ivdnt.org/over-ons/contact/medewerkers</Url>
                </Contact>
             </Creator>
          </SoftwareDevelopment>

--- a/legacy/cmdi/Autonomata-POI-demo.cmdi.xml
+++ b/legacy/cmdi/Autonomata-POI-demo.cmdi.xml
@@ -97,7 +97,7 @@
                <Email>servicedesk@tst-centrale.org</Email>
                <Organisation xml:lang="nld">Instituut voor de Nederlandse Taal</Organisation>
                <Organisation xml:lang="eng">Institute for the Dutch Language</Organisation>
-               <Url>http://www.ivdnt.org/</Url>
+               <Url>https://www.ivdnt.org/</Url>
             </Contact>
          </Access>
          <ResourceDocumentation>

--- a/legacy/cmdi/Autonomata-transcriptietool.cmdi.xml
+++ b/legacy/cmdi/Autonomata-transcriptietool.cmdi.xml
@@ -97,7 +97,7 @@
                <Email>servicedesk@tst-centrale.org</Email>
                <Organisation xml:lang="nld">Instituut voor de Nederlandse Taal</Organisation>
                <Organisation xml:lang="eng">Institute for the Dutch Language</Organisation>
-               <Url>http://www.ivdnt.org/</Url>
+               <Url>https://www.ivdnt.org/</Url>
             </Contact>
          </Access>
          <ResourceDocumentation>

--- a/legacy/cmdi/CHN.cmdi.xml
+++ b/legacy/cmdi/CHN.cmdi.xml
@@ -10,7 +10,7 @@
       <ResourceProxyList>
 	  <ResourceProxy id="CHN001">
 			<ResourceType>Resource</ResourceType>
-			<ResourceRef>http://chn.inl.nl/</ResourceRef>
+			<ResourceRef>https://chn.ivdnt.org/</ResourceRef>
 	  </ResourceProxy>	
 	</ResourceProxyList>
       <JournalFileProxyList/>
@@ -24,7 +24,7 @@
             <title xml:lang="nld">Corpus Hedendaags Nederlands</title>
             <title xml:lang="eng">Corpus of Contemporary Dutch</title>
             <publicationYear>2013</publicationYear>
-            <url>http://chn.inl.nl</url><CLARINCentre>Dutch Language Institute</CLARINCentre>
+            <url>https://chn.ivdnt.org/</url><CLARINCentre>Dutch Language Institute</CLARINCentre>
             <ReleaseStatus>
                <LifeCycleStatus>published</LifeCycleStatus>
                <lastUpdate>2014-10-06</lastUpdate>
@@ -116,7 +116,7 @@
                <license>other</license>
                <distributionType>academic</distributionType>
 	       <availability>Free, accessible through CLARIN Institutional login</availability>
-               <url>https://portal.clarin.inl.nl/opensonar_whitelab/page/search</url>
+               <url>https://chn.ivdnt.org/</url>
                <Price>
                   <amount>0</amount>
                   <ISO4217>
@@ -128,14 +128,14 @@
               <Email>servicedesk@ivdnt.org</Email>
               <Organisation xml:lang="nld">Instituut voor de Nederlandse Taal</Organisation>
               <Organisation xml:lang="eng">Institute for the Dutch Language</Organisation>
-              <Url>http://www.ivdnt.org/</Url>
+              <Url>https://www.ivdnt.org/</Url>
             </Contact>
          </Access>
          <ResourceDocumentation>
             <Documentation>
                <title>HELP</title>
                <documentationTarget>user</documentationTarget>
-               <url>https://portal.clarin.inl.nl/search/page/help#help</url>
+               <url>https://portal.clarin.ivdnt.org/corpus-frontend-chn/chn-extern/help</url>
                <ISO639>
                   <iso-639-3-code>eng</iso-639-3-code>
                </ISO639>
@@ -146,12 +146,12 @@
                <name>CHN</name>
                <title>Corpus Hedendaags Nederlands</title>
                <funder>NTU/IMPACT/CLARIN</funder>
-               <url>https://portal.clarin.inl.nl/search/page/help</url>
+               <url>https://portal.clarin.ivdnt.org/corpus-frontend-chn/chn-extern/help</url>
                <Contact>
                   <Email>servicedesk@ivdnt.org</Email>
 		  <Organisation xml:lang="nld">Instituut voor de Nederlandse Taal</Organisation>
 		  <Organisation xml:lang="eng">Institute for the Dutch Language</Organisation>
-		  <Url>http://www.ivdnt.org/</Url>
+		  <Url>https://www.ivdnt.org/</Url>
                </Contact>
                <Duration/>
             </Project>
@@ -160,7 +160,7 @@
                   <Email>servicedesk@ivdnt.org</Email>
 		  <Organisation xml:lang="nld">Instituut voor de Nederlandse Taal</Organisation>
 		  <Organisation xml:lang="eng">Institute for the Dutch Language</Organisation>
-		  <Url>http://www.ivdnt.org/</Url>
+		  <Url>https://www.ivdnt.org/</Url>
 	      </Contact>
 	    </Creator>
          </SoftwareDevelopment>

--- a/legacy/cmdi/Corea.cmdi.xml
+++ b/legacy/cmdi/Corea.cmdi.xml
@@ -87,7 +87,7 @@
                <Email>servicedesk@ivdnt.org</Email>
                <Organisation xml:lang="nld">Instituut voor de Nederlandse Taal</Organisation>
                <Organisation xml:lang="eng">Institute for the Dutch Language</Organisation>
-               <Url>http://www.ivdnt.org/</Url>
+               <Url>https://www.ivdnt.org/</Url>
             </Contact>
          </Access>
          <ResourceDocumentation>

--- a/legacy/cmdi/Cornetto.cmdi.xml
+++ b/legacy/cmdi/Cornetto.cmdi.xml
@@ -126,7 +126,7 @@
                <Email>servicedesk@ivdnt.org</Email>
                <Organisation xml:lang="nld">Instituut voor de Nederlandse Taal</Organisation>
                <Organisation xml:lang="eng">Institute for the Dutch Language</Organisation>
-               <Url>http://www.ivdnt.org/</Url>
+               <Url>https://www.ivdnt.org/</Url>
             </Contact>
          </Access>
          <ResourceDocumentation>

--- a/legacy/cmdi/CorpusGysseling.cmdi.xml
+++ b/legacy/cmdi/CorpusGysseling.cmdi.xml
@@ -36,7 +36,7 @@
             <title xml:lang="eng"/>
             <owner>INL</owner>
             <publicationYear>2008</publicationYear>
-            <url>http://gysseling.corpus.taalbanknederlands.ivdnt.org/gysseling/page/search/</url><CLARINCentre>Dutch Language Institute</CLARINCentre>
+            <url>https://corpusgysseling.ivdnt.org/corpus-frontend/Gysseling/search</url><CLARINCentre>Dutch Language Institute</CLARINCentre>
             <ReleaseStatus>
                <LifeCycleStatus>published</LifeCycleStatus>
                <lastUpdate>2013-01-01</lastUpdate>
@@ -106,7 +106,7 @@
                <Email>servicedesk@ivdnt.org</Email>
                <Organisation xml:lang="nld">Instituut voor de Nederlandse Taal</Organisation>
                <Organisation xml:lang="eng">Institute for the Dutch Language</Organisation>
-               <Url>http://www.ivdnt.org/</Url>
+               <Url>https://www.ivdnt.org/</Url>
             </Contact>
          </Access>
          <ResourceDocumentation>
@@ -130,7 +130,7 @@
 		 <Email>servicedesk@ivdnt.org</Email>
 		 <Organisation xml:lang="nld">Instituut voor de Nederlandse Taal</Organisation>
 		 <Organisation xml:lang="eng">Institute for the Dutch Language</Organisation>
-		 <Url>http://www.ivdnt.org/</Url>
+		 <Url>https://www.ivdnt.org/</Url>
                </Contact>
                <Duration/>
             </Project>
@@ -141,7 +141,7 @@
                 <Email>katrien.depuydt@ivdnt.org</Email>
 		<Organisation xml:lang="nld">Instituut voor de Nederlandse Taal</Organisation>
 		<Organisation xml:lang="eng">Institute for the Dutch Language</Organisation>
-		<Url>http://www.ivdnt.org/over-ons/contact/medewerkers</Url>
+		<Url>https://www.ivdnt.org/over-ons/contact/medewerkers</Url>
               </Contact>
             </Creator>
          </SoftwareDevelopment>

--- a/legacy/cmdi/DuELME.cmdi.xml
+++ b/legacy/cmdi/DuELME.cmdi.xml
@@ -100,7 +100,7 @@
                <Email>servicedesk@ivdnt.org</Email>
                <Organisation xml:lang="nld">Instituut voor de Nederlandse Taal</Organisation>
                <Organisation xml:lang="eng">Institute for the Dutch Language</Organisation>
-               <Url>http://www.ivdnt.org/</Url>
+               <Url>https://www.ivdnt.org/</Url>
             </Contact>
          </Access>
          <ResourceDocumentation>
@@ -115,7 +115,7 @@
             <Documentation>
                <title>user documentation</title>
                <documentationTarget>user</documentationTarget>
-               <url>http://www.ivdnt.org/images/stories/producten/duelme_lmf_documentation.zip</url>
+               <url>https://www.ivdnt.org/images/stories/producten/duelme_lmf_documentation.zip</url>
                <ISO639>
                   <iso-639-3-code>eng</iso-639-3-code>
                </ISO639>

--- a/legacy/cmdi/Dupira.cmdi.xml
+++ b/legacy/cmdi/Dupira.cmdi.xml
@@ -90,7 +90,7 @@
                <Email>servicedesk@ivdnt.org</Email>
                <Organisation xml:lang="nld">Instituut voor de Nederlandse Taal</Organisation>
                <Organisation xml:lang="eng">Institute for the Dutch Language</Organisation>
-               <Url>http://www.ivdnt.org/</Url>
+               <Url>https://www.ivdnt.org/</Url>
             </Contact>
          </Access>
          <ResourceDocumentation>

--- a/legacy/cmdi/Frog.cmdi.xml
+++ b/legacy/cmdi/Frog.cmdi.xml
@@ -104,7 +104,7 @@
                <Email>servicedesk@ivdnt.org</Email>
                <Organisation xml:lang="nld">Instituut voor de Nederlandse Taal</Organisation>
                <Organisation xml:lang="eng">Institute for the Dutch Language</Organisation>
-               <Url>http://www.ivdnt.org/</Url>
+               <Url>https://www.ivdnt.org/</Url>
             </Contact>
          </Access>
          <ResourceDocumentation>

--- a/legacy/cmdi/LASSY.cmdi.xml
+++ b/legacy/cmdi/LASSY.cmdi.xml
@@ -96,7 +96,7 @@
                <Email>servicedesk@ivdnt.org</Email>
                <Organisation xml:lang="nld">Instituut voor de Nederlandse Taal</Organisation>
                <Organisation xml:lang="eng">Institute for the Dutch Language</Organisation>
-               <Url>http://www.ivdnt.org/</Url>
+               <Url>https://www.ivdnt.org/</Url>
             </Contact>
          </Access>
          <ResourceDocumentation>

--- a/legacy/cmdi/MNW.cmdi.xml
+++ b/legacy/cmdi/MNW.cmdi.xml
@@ -32,7 +32,7 @@
             <title xml:lang="nld">Middelnederlandsch Woordenboek</title>
             <title xml:lang="eng">Dictionary of Middle Dutch</title>
             <publicationYear>2009</publicationYear>
-            <url>http://gtb.ivdnt.org/</url><CLARINCentre>Dutch Language Institute</CLARINCentre>
+            <url>https://gtb.ivdnt.org/</url><CLARINCentre>Dutch Language Institute</CLARINCentre>
             <ReleaseStatus>
                <LifeCycleStatus>published</LifeCycleStatus>
                <lastUpdate>2015-12-10</lastUpdate>
@@ -123,7 +123,7 @@
                <license>unknown</license>
                <distributionType>academic</distributionType>
 	       <availability>free for academic use; non applicable for commercial parties</availability>
-               <url>http://gtb.ivdnt.org/openlaszlo/my-apps/GTB/Productie/HuidigeVersie/src/inlgtb.html</url>
+               <url>https://gtb.ivdnt.org/</url>
                <Price>
                   <amount>0</amount>
                   <ISO4217>
@@ -135,16 +135,16 @@
                <Email>servicedesk@ivdnt.org</Email>
                <Organisation xml:lang="nld">Instituut voor de Nederlandse Taal</Organisation>
                <Organisation xml:lang="eng">Institute for the Dutch Language</Organisation>
-               <Url>http://www.ivdnt.org/</Url>
+               <Url>https://www.ivdnt.org/</Url>
             </Contact>
          </Access>
          <ResourceDocumentation>
             <Documentation>
-               <title>Frequently Asked Questions</title>
+               <title>Help</title>
                <documentationTarget>user</documentationTarget>
-               <url>http://gtb.ivdnt.org/openlaszlo/my-apps/GTB/Productie/HuidigeVersie/src/faq.html</url>
+               <url>https://gtb.ivdnt.org/</url>
                <ISO639>
-                  <iso-639-3-code>eng</iso-639-3-code>
+                  <iso-639-3-code>nld</iso-639-3-code>
                </ISO639>
             </Documentation>
          </ResourceDocumentation>
@@ -153,12 +153,12 @@
                <name>GTB</name>
                <title>Geïntegreerde Taalbank Nederlands</title>
                <funder>IVDNT.ORG</funder>
-               <url>http://ivdnt.org</url>
+               <url>https://ivdnt.org</url>
                <Contact>
 		 <Email>servicedesk@ivdnt.org</Email>
 		 <Organisation xml:lang="nld">Instituut voor de Nederlandse Taal</Organisation>
 		 <Organisation xml:lang="eng">Institute for the Dutch Language</Organisation>
-		 <Url>http://www.ivdnt.org/</Url>
+		 <Url>https://www.ivdnt.org/</Url>
                </Contact>
                <Duration/>
             </Project>
@@ -168,7 +168,7 @@
                  <Email>katrien.depuydt@ivdnt.org</Email>
 		 <Organisation xml:lang="nld">Instituut voor de Nederlandse Taal</Organisation>
 		 <Organisation xml:lang="eng">Institute for the Dutch Language</Organisation>
-		 <Url>http://www.ivdnt.org/over-ons/contact/medewerkers</Url>
+		 <Url>https://www.ivdnt.org/over-ons/contact/medewerkers</Url>
                </Contact>
             </Creator>
          </SoftwareDevelopment>

--- a/legacy/cmdi/Namescape_Browser.cmdi.xml
+++ b/legacy/cmdi/Namescape_Browser.cmdi.xml
@@ -108,7 +108,7 @@
                <Email>servicedesk@ivdnt.org</Email>
                <Organisation xml:lang="nld">Instituut voor de Nederlandse Taal</Organisation>
                <Organisation xml:lang="eng">Institute for the Dutch Language</Organisation>
-               <Url>http://www.ivdnt.org/</Url>
+               <Url>https://www.ivdnt.org/</Url>
             </Contact>
          </Access>
          <ResourceDocumentation>
@@ -190,7 +190,7 @@
 	       <Email/>
                <Organisation xml:lang="nld">Instituut voor de Nederlandse Taal</Organisation>
                <Organisation xml:lang="eng">Institute for the Dutch Language</Organisation>
-	       <Url>http://www.ivdnt.org/over-ons/contact/medewerkers</Url>
+	       <Url>https://www.ivdnt.org/over-ons/contact/medewerkers</Url>
             </Contact>
 	    </Creator>
 	    <Creator>
@@ -200,7 +200,7 @@
 		<Email/>
 		<Organisation xml:lang="nld">Instituut voor de Nederlandse Taal</Organisation>
 		<Organisation xml:lang="eng">Institute for the Dutch Language</Organisation>
-		<Url>http://www.ivdnt.org/over-ons/contact/medewerkers</Url>
+		<Url>https://www.ivdnt.org/over-ons/contact/medewerkers</Url>
               </Contact>
 	    </Creator>
 	    <Creator>
@@ -210,7 +210,7 @@
 		<Email/>
 		<Organisation xml:lang="nld">Instituut voor de Nederlandse Taal</Organisation>
 		<Organisation xml:lang="eng">Institute for the Dutch Language</Organisation>
-		<Url>http://www.ivdnt.org/over-ons/contact/medewerkers</Url>
+		<Url>https://www.ivdnt.org/over-ons/contact/medewerkers</Url>
               </Contact>
 	    </Creator>
          </SoftwareDevelopment>

--- a/legacy/cmdi/Namescape_NER.cmdi.xml
+++ b/legacy/cmdi/Namescape_NER.cmdi.xml
@@ -139,7 +139,7 @@
                <Email>servicedesk@ivdnt.org</Email>
                <Organisation xml:lang="nld">Instituut voor de Nederlandse Taal</Organisation>
                <Organisation xml:lang="eng">Institute for the Dutch Language</Organisation>
-               <Url>http://www.ivdnt.org/</Url>
+               <Url>https://www.ivdnt.org/</Url>
             </Contact>
          </Access>
          <ResourceDocumentation>
@@ -221,7 +221,7 @@
 	       <Email/>
                <Organisation xml:lang="nld">Instituut voor de Nederlandse Taal</Organisation>
                <Organisation xml:lang="eng">Institute for the Dutch Language</Organisation>
-	       <Url>http://www.ivdnt.org/over-ons/contact/medewerkers</Url>
+	       <Url>https://www.ivdnt.org/over-ons/contact/medewerkers</Url>
             </Contact>
 	    </Creator>
 	    <Creator>
@@ -231,7 +231,7 @@
 		<Email/>
 		<Organisation xml:lang="nld">Instituut voor de Nederlandse Taal</Organisation>
 		<Organisation xml:lang="eng">Institute for the Dutch Language</Organisation>
-		<Url>http://www.ivdnt.org/over-ons/contact/medewerkers</Url>
+		<Url>https://www.ivdnt.org/over-ons/contact/medewerkers</Url>
               </Contact>
 	    </Creator>
 	    <Creator>
@@ -241,7 +241,7 @@
 		<Email/>
 		<Organisation xml:lang="nld">Instituut voor de Nederlandse Taal</Organisation>
 		<Organisation xml:lang="eng">Institute for the Dutch Language</Organisation>
-		<Url>http://www.ivdnt.org/over-ons/contact/medewerkers</Url>
+		<Url>https://www.ivdnt.org/over-ons/contact/medewerkers</Url>
               </Contact>
 	    </Creator>
          </SoftwareDevelopment>

--- a/legacy/cmdi/Namescape_Search.cmdi.xml
+++ b/legacy/cmdi/Namescape_Search.cmdi.xml
@@ -109,7 +109,7 @@
                <Email>servicedesk@ivdnt.org</Email>
                <Organisation xml:lang="nld">Instituut voor de Nederlandse Taal</Organisation>
                <Organisation xml:lang="eng">Institute for the Dutch Language</Organisation>
-               <Url>http://www.ivdnt.org/</Url>
+               <Url>https://www.ivdnt.org/</Url>
             </Contact>
          </Access>
          <ResourceDocumentation>
@@ -191,7 +191,7 @@
 	       <Email/>
                <Organisation xml:lang="nld">Instituut voor de Nederlandse Taal</Organisation>
                <Organisation xml:lang="eng">Institute for the Dutch Language</Organisation>
-	       <Url>http://www.ivdnt.org/over-ons/contact/medewerkers</Url>
+	       <Url>https://www.ivdnt.org/over-ons/contact/medewerkers</Url>
             </Contact>
 	    </Creator>
 	    <Creator>
@@ -201,7 +201,7 @@
 		<Email/>
 		<Organisation xml:lang="nld">Instituut voor de Nederlandse Taal</Organisation>
 		<Organisation xml:lang="eng">Institute for the Dutch Language</Organisation>
-		<Url>http://www.ivdnt.org/over-ons/contact/medewerkers</Url>
+		<Url>https://www.ivdnt.org/over-ons/contact/medewerkers</Url>
               </Contact>
 	    </Creator>
 	    <Creator>
@@ -211,7 +211,7 @@
 		<Email/>
 		<Organisation xml:lang="nld">Instituut voor de Nederlandse Taal</Organisation>
 		<Organisation xml:lang="eng">Institute for the Dutch Language</Organisation>
-		<Url>http://www.ivdnt.org/over-ons/contact/medewerkers</Url>
+		<Url>https://www.ivdnt.org/over-ons/contact/medewerkers</Url>
               </Contact>
 	    </Creator>
          </SoftwareDevelopment>

--- a/legacy/cmdi/Namescape_Visualizer.cmdi.xml
+++ b/legacy/cmdi/Namescape_Visualizer.cmdi.xml
@@ -108,7 +108,7 @@
                <Email>servicedesk@ivdnt.org</Email>
                <Organisation xml:lang="nld">Instituut voor de Nederlandse Taal</Organisation>
                <Organisation xml:lang="eng">Institute for the Dutch Language</Organisation>
-               <Url>http://www.ivdnt.org/</Url>
+               <Url>https://www.ivdnt.org/</Url>
             </Contact>
          </Access>
          <ResourceDocumentation>
@@ -190,7 +190,7 @@
 	       <Email/>
                <Organisation xml:lang="nld">Instituut voor de Nederlandse Taal</Organisation>
                <Organisation xml:lang="eng">Institute for the Dutch Language</Organisation>
-	       <Url>http://www.ivdnt.org/over-ons/contact/medewerkers</Url>
+	       <Url>https://www.ivdnt.org/over-ons/contact/medewerkers</Url>
             </Contact>
 	    </Creator>
 	    <Creator>
@@ -200,7 +200,7 @@
 		<Email/>
 		<Organisation xml:lang="nld">Instituut voor de Nederlandse Taal</Organisation>
 		<Organisation xml:lang="eng">Institute for the Dutch Language</Organisation>
-		<Url>http://www.ivdnt.org/over-ons/contact/medewerkers</Url>
+		<Url>https://www.ivdnt.org/over-ons/contact/medewerkers</Url>
               </Contact>
 	    </Creator>
 	    <Creator>
@@ -210,7 +210,7 @@
 		<Email/>
 		<Organisation xml:lang="nld">Instituut voor de Nederlandse Taal</Organisation>
 		<Organisation xml:lang="eng">Institute for the Dutch Language</Organisation>
-		<Url>http://www.ivdnt.org/over-ons/contact/medewerkers</Url>
+		<Url>https://www.ivdnt.org/over-ons/contact/medewerkers</Url>
               </Contact>
 	    </Creator>
          </SoftwareDevelopment>

--- a/legacy/cmdi/ONW.cmdi.xml
+++ b/legacy/cmdi/ONW.cmdi.xml
@@ -32,7 +32,7 @@
             <title xml:lang="nld">Oudnederlands Woordenboek</title>
             <title xml:lang="eng">Dictionary of Old Dutch</title>
             <publicationYear>2009</publicationYear>
-            <url>http://gtb.inl.nl/</url><CLARINCentre>Dutch Language Institute</CLARINCentre>
+            <url>https://gtb.ivdnt.org/</url><CLARINCentre>Dutch Language Institute</CLARINCentre>
             <ReleaseStatus>
                <LifeCycleStatus>published</LifeCycleStatus>
                <lastUpdate>2015-12-10</lastUpdate>
@@ -122,7 +122,7 @@
                <license>unknown</license>
                <distributionType>academic</distributionType>
 	       <availability>free for academic use; non applicable for commercial parties</availability>
-               <url>http://gtb.ivdnt.org/openlaszlo/my-apps/GTB/Productie/HuidigeVersie/src/inlgtb.html</url>
+               <url>https://gtb.ivdnt.org/openlaszlo/my-apps/GTB/Productie/HuidigeVersie/src/inlgtb.html</url>
                <Price>
                   <amount>0</amount>
                   <ISO4217>
@@ -134,16 +134,16 @@
                <Email>servicedesk@ivdnt.org</Email>
                <Organisation xml:lang="nld">Instituut voor de Nederlandse Taal</Organisation>
                <Organisation xml:lang="eng">Institute for the Dutch Language</Organisation>
-               <Url>http://www.ivdnt.org/</Url>
+               <Url>https://www.ivdnt.org/</Url>
             </Contact>
          </Access>
          <ResourceDocumentation>
             <Documentation>
-               <title>Frequently Asked Questions</title>
+               <title>Help</title>
                <documentationTarget>user</documentationTarget>
-               <url>http://gtb.ivdnt.org/openlaszlo/my-apps/GTB/Productie/HuidigeVersie/src/faq.html</url>
+               <url>https://gtb.ivdnt.org/</url>
                <ISO639>
-                  <iso-639-3-code>eng</iso-639-3-code>
+                  <iso-639-3-code>nld</iso-639-3-code>
                </ISO639>
             </Documentation>
          </ResourceDocumentation>
@@ -152,12 +152,12 @@
                <name>GTB</name>
                <title>Geïntegreerde Taalbank Nederlands</title>
                <funder>IVDNT.ORG</funder>
-               <url>http://ivdnt.org</url>
+               <url>https://ivdnt.org</url>
                <Contact>
 		 <Email>servicedesk@ivdnt.org</Email>
 		 <Organisation xml:lang="nld">Instituut voor de Nederlandse Taal</Organisation>
 		 <Organisation xml:lang="eng">Institute for the Dutch Language</Organisation>
-		 <Url>http://www.ivdnt.org/</Url>
+		 <Url>https://www.ivdnt.org/</Url>
                </Contact>
                <Duration/>
             </Project>
@@ -167,7 +167,7 @@
                   <Email>katrien.depuydt@ivdnt.org</Email>
 		  <Organisation xml:lang="nld">Instituut voor de Nederlandse Taal</Organisation>
 		  <Organisation xml:lang="eng">Institute for the Dutch Language</Organisation>
-		  <Url>http://www.ivdnt.org/over-ons/contact/medewerkers</Url>
+		  <Url>https://www.ivdnt.org/over-ons/contact/medewerkers</Url>
                </Contact>
             </Creator>
          </SoftwareDevelopment>

--- a/legacy/cmdi/OpenConvert.cmdi.xml
+++ b/legacy/cmdi/OpenConvert.cmdi.xml
@@ -60,7 +60,7 @@
          <SoftwareImplementation>
             <distributionMedium>Download</distributionMedium>
             <distributionMedium>Online available</distributionMedium>
-			<sourcecodeURI>https://github.com/INL/OpenConvert</sourcecodeURI>
+			<sourcecodeURI>https://github.com/instituutnederlandsetaal/OpenConvert</sourcecodeURI>
             <UserInterface>
                <interfaceType>command line interface</interfaceType>
                <applicationType>local desktop</applicationType>
@@ -156,7 +156,7 @@
             <ResourceLicense>
                <license>other</license>
                <distributionType>public</distributionType>
-               <url>https://github.com/INL/OpenConvert</url>
+               <url>https://github.com/instituutnederlandsetaal/OpenConvert</url>
 	       <Description>
 		 <Description>Free for academic use. Non-applicable for commercial parties</Description>
                  <Description>CLARIN based login required. The Clarin federation accepts login from many europian institutions. please seehttp://www.clarin.eu/content/service-provider-federation for more details </Description>
@@ -172,7 +172,7 @@
                <Email>servicedesk@ivdnt.org</Email>
                <Organisation xml:lang="nld">Instituut voor de Nederlandse Taal</Organisation>
                <Organisation xml:lang="eng">Institute for the Dutch Language</Organisation>
-               <Url>http://www.ivdnt.org/</Url>
+               <Url>https://www.ivdnt.org/</Url>
             </Contact>
          </Access>
          <ResourceDocumentation>
@@ -209,7 +209,7 @@
                  <Email>jantheo.bakker@ivdnt.org</Email>
 		 <Organisation xml:lang="nld">Instituut voor de Nederlandse Taal</Organisation>
 		 <Organisation xml:lang="eng">Institute for the Dutch Language</Organisation>
-		 <Url>http://www.ivdnt.org/over-ons/contact/medewerkers</Url>
+		 <Url>https://www.ivdnt.org/over-ons/contact/medewerkers</Url>
                </Contact>
                <Duration/>
             </Project>
@@ -220,7 +220,7 @@
                  <Email>jantheo.bakker@ivdnt.org</Email>
 		 <Organisation xml:lang="nld">Instituut voor de Nederlandse Taal</Organisation>
 		 <Organisation xml:lang="eng">Institute for the Dutch Language</Organisation>
-		 <Url>http://www.ivdnt.org/over-ons/contact/medewerkers</Url>
+		 <Url>https://www.ivdnt.org/over-ons/contact/medewerkers</Url>
                </Contact>
             </Creator>
          </SoftwareDevelopment>

--- a/legacy/cmdi/OpenSONAR.cmdi.xml
+++ b/legacy/cmdi/OpenSONAR.cmdi.xml
@@ -10,7 +10,7 @@
 	<ResourceProxyList>
 		<ResourceProxy id="OpenSoNaR001">
 			<ResourceType>SearchPage</ResourceType>
-			<ResourceRef> http://opensonar.inl.nl</ResourceRef>
+			<ResourceRef>https://opensonar.ivdnt.org/</ResourceRef>
 		</ResourceProxy>
 	</ResourceProxyList>
 	<JournalFileProxyList/>
@@ -22,7 +22,7 @@
             <name xml:lang="eng">OpenSONAR</name>
             <title xml:lang="eng">OpenSONAR: a 500 MW reference corpus of Contemporary Written Dutch</title>
             <publicationYear>2013</publicationYear>
-            <url> http://opensonar.inl.nl</url><CLARINCentre>Dutch Language Institute</CLARINCentre><OriginalSource>http://portal.clarin.nl/node/4195</OriginalSource>
+            <url>https://opensonar.ivdnt.org/</url><CLARINCentre>Dutch Language Institute</CLARINCentre><OriginalSource>http://portal.clarin.nl/node/4195</OriginalSource>
             <ReleaseStatus>
                <LifeCycleStatus>published</LifeCycleStatus>
                <lastUpdate>2014-10-06</lastUpdate>
@@ -102,12 +102,12 @@
             </Output>
          </SoftwareImplementation>
          <Access>
-	   <catalogueLink>https://portal.clarin.inl.nl</catalogueLink>
+	   <catalogueLink>https://portal.clarin.ivdnt.org</catalogueLink>
             <ResourceLicense>
                <license>other</license>
                <distributionType>academic</distributionType>
 	       <availability>Free, accessible through CLARIN Institutional login</availability>
-               <url>https://portal.clarin.inl.nl/opensonar_whitelab/page/search</url>
+               <url>https://opensonar.ivdnt.org/</url>
                <Price>
                   <amount>0</amount>
                   <ISO4217>
@@ -119,7 +119,7 @@
               <Email>servicedesk@ivdnt.org</Email>
               <Organisation xml:lang="nld">Instituut voor de Nederlandse Taal</Organisation>
               <Organisation xml:lang="eng">Institute for the Dutch Language</Organisation>
-              <Url>http://www.ivdnt.org/</Url>
+              <Url>https://www.ivdnt.org/</Url>
             </Contact>
          </Access>
          <ResourceDocumentation>

--- a/legacy/cmdi/PhilosTEI.cmdi.xml
+++ b/legacy/cmdi/PhilosTEI.cmdi.xml
@@ -208,7 +208,7 @@
               <Email>servicedesk@ivdnt.org</Email>
               <Organisation xml:lang="nld">Instituut voor de Nederlandse Taal</Organisation>
               <Organisation xml:lang="eng">Institute for the Dutch Language</Organisation>
-              <Url>http://www.ivdnt.org/</Url>
+              <Url>https://www.ivdnt.org/</Url>
             </Contact>
          </Access>
          <ResourceDocumentation>

--- a/legacy/cmdi/TICClops.cmdi.xml
+++ b/legacy/cmdi/TICClops.cmdi.xml
@@ -210,7 +210,7 @@
               <Email>servicedesk@ivdnt.org</Email>
               <Organisation xml:lang="nld">Instituut voor de Nederlandse Taal</Organisation>
               <Organisation xml:lang="eng">Institute for the Dutch Language</Organisation>
-              <Url>http://www.ivdnt.org/</Url>
+              <Url>https://www.ivdnt.org/</Url>
             </Contact>
          </Access>
          <ResourceDocumentation>

--- a/legacy/cmdi/Taalportaal.cmdi.xml
+++ b/legacy/cmdi/Taalportaal.cmdi.xml
@@ -117,30 +117,14 @@
                <Email>servicedesk@ivdnt.org</Email>
                <Organisation xml:lang="nld">Instituut voor de Nederlandse Taal</Organisation>
                <Organisation xml:lang="eng">Institute for the Dutch Language</Organisation>
-               <Url>http://www.ivdnt.org/</Url>
+               <Url>https://www.ivdnt.org/</Url>
             </Contact>
          </Access>
          <ResourceDocumentation>
             <Documentation>
-               <title>Frequently Asked Questions</title>
-               <documentationTarget>user</documentationTarget>
-               <url>http://taalportaal.org/taalportaal/resources/qanda.html</url>
-               <ISO639>
-                  <iso-639-3-code>eng</iso-639-3-code>
-               </ISO639>
-            </Documentation>
-            <Documentation>
-               <title>Help</title>
-               <documentationTarget>user</documentationTarget>
-               <url>http://taalportaal.org/taalportaal/resources/help.html</url>
-               <ISO639>
-                  <iso-639-3-code>eng</iso-639-3-code>
-               </ISO639>
-            </Documentation>
-            <Documentation>
                <title>About</title>
                <documentationTarget>user</documentationTarget>
-               <url>http://taalportaal.org/taalportaal/resources/about.html</url>
+               <url>https://taalportaal.org/res/taalportaal/about.html</url>
                <ISO639>
                   <iso-639-3-code>eng</iso-639-3-code>
                </ISO639>

--- a/legacy/cmdi/VMNW.cmdi.xml
+++ b/legacy/cmdi/VMNW.cmdi.xml
@@ -32,7 +32,7 @@
             <title xml:lang="nld">Vroegmiddelnederlands Woordenboek</title>
             <title xml:lang="eng">Dictionary of Early Middle Dutch</title>
             <publicationYear>2007</publicationYear>
-            <url>http://gtb.ivdnt.org/</url><CLARINCentre>Dutch Language Institute</CLARINCentre>
+            <url>https://gtb.ivdnt.org/</url><CLARINCentre>Dutch Language Institute</CLARINCentre>
             <ReleaseStatus>
                <LifeCycleStatus>published</LifeCycleStatus>
                <lastUpdate>2015-12-10</lastUpdate>
@@ -122,7 +122,7 @@
                <license>unknown</license>
                <distributionType>academic</distributionType>
 	       <availability>free for academic use; non applicable for commercial parties</availability>
-               <url>http://gtb.ivdnt.org/openlaszlo/my-apps/GTB/Productie/HuidigeVersie/src/inlgtb.html</url>
+               <url>https://gtb.ivdnt.org/openlaszlo/my-apps/GTB/Productie/HuidigeVersie/src/inlgtb.html</url>
                <Price>
                   <amount>0</amount>
                   <ISO4217>
@@ -134,16 +134,16 @@
               <Email>servicedesk@ivdnt.org</Email>
               <Organisation xml:lang="nld">Instituut voor de Nederlandse Taal</Organisation>
               <Organisation xml:lang="eng">Institute for the Dutch Language</Organisation>
-              <Url>http://www.ivdnt.org/</Url>
+              <Url>https://www.ivdnt.org/</Url>
             </Contact>
          </Access>
          <ResourceDocumentation>
             <Documentation>
-               <title>Frequently Asked Questions</title>
+               <title>Help</title>
                <documentationTarget>user</documentationTarget>
-               <url>http://gtb.ivdnt.org/openlaszlo/my-apps/GTB/Productie/HuidigeVersie/src/faq.html</url>
+               <url>https://gtb.ivdnt.org/</url>
                <ISO639>
-                  <iso-639-3-code>eng</iso-639-3-code>
+                  <iso-639-3-code>nld</iso-639-3-code>
                </ISO639>
             </Documentation>
          </ResourceDocumentation>
@@ -152,12 +152,12 @@
                <name>GTB</name>
                <title>Geïntegreerde Taalbank Nederlands</title>
                <funder>IVDNT.ORG</funder>
-               <url>http://ivdnt.org</url>
+               <url>https://ivdnt.org</url>
                <Contact>
 		 <Email>servicedesk@ivdnt.org</Email>
 		 <Organisation xml:lang="nld">Instituut voor de Nederlandse Taal</Organisation>
 		 <Organisation xml:lang="eng">Institute for the Dutch Language</Organisation>
-		 <Url>http://www.ivdnt.org/</Url>
+		 <Url>https://www.ivdnt.org/</Url>
                </Contact>
                <Duration/>
             </Project>
@@ -167,7 +167,7 @@
                   <Email>katrien.depuydt@ivdnt.org</Email>
 		  <Organisation xml:lang="nld">Instituut voor de Nederlandse Taal</Organisation>
 		  <Organisation xml:lang="eng">Institute for the Dutch Language</Organisation>
-		  <Url>http://www.ivdnt.org/over-ons/contact/medewerkers</Url>
+		  <Url>https://www.ivdnt.org/over-ons/contact/medewerkers</Url>
                </Contact>
             </Creator>
          </SoftwareDevelopment>

--- a/legacy/cmdi/VU-DNC.cmdi.xml
+++ b/legacy/cmdi/VU-DNC.cmdi.xml
@@ -26,7 +26,7 @@
             <name xml:lang="eng">VU-DNC</name>
             <title xml:lang="eng">VU University Diachronic News text Corpus</title>
             <publicationYear>2013</publicationYear>
-            <url>http://portal.clarin.inl.nl/vu-dnc/</url><CLARINCentre>Dutch Language Institute</CLARINCentre><OriginalSource>http://portal.clarin.nl/node/4194</OriginalSource>
+            <url>https://portal.clarin.ivdnt.org/vu-dnc/</url><CLARINCentre>Dutch Language Institute</CLARINCentre><OriginalSource>http://portal.clarin.nl/node/4194</OriginalSource>
             <ReleaseStatus>
                <LifeCycleStatus>published</LifeCycleStatus>
                <lastUpdate>2014-10-06</lastUpdate>
@@ -118,7 +118,7 @@
             </Output>
          </SoftwareImplementation>
          <Access>
-	   <catalogueLink>https://portal.clarin.inl.nl/vu-dnc/</catalogueLink>
+	   <catalogueLink>https://portal.clarin.ivdnt.org/vu-dnc/</catalogueLink>
             <ResourceLicense>
                <license>other</license>
                <distributionType>academic</distributionType>
@@ -135,7 +135,7 @@
               <Email>servicedesk@ivdnt.org</Email>
               <Organisation xml:lang="nld">Instituut voor de Nederlandse Taal</Organisation>
               <Organisation xml:lang="eng">Institute for the Dutch Language</Organisation>
-              <Url>http://www.ivdnt.org/</Url>
+              <Url>https://www.ivdnt.org/</Url>
             </Contact>
          </Access>
          <ResourceDocumentation>
@@ -184,7 +184,7 @@
 		<Email>	laura.vaneerten@ivdnt.org</Email>
 		<Organisation xml:lang="nld">Instituut voor de Nederlandse Taal</Organisation>
 		<Organisation xml:lang="eng">Institute for the Dutch Language</Organisation>
-		<Url>http://www.ivdnt.org/over-ons/contact/medewerkers</Url>
+		<Url>https://www.ivdnt.org/over-ons/contact/medewerkers</Url>
 	      </Contact>
 	    </Creator>
 	    <Creator>

--- a/legacy/cmdi/WFT_GTB.cmdi.xml
+++ b/legacy/cmdi/WFT_GTB.cmdi.xml
@@ -30,7 +30,7 @@
             <name xml:lang="eng">WFT-GTB</name>
             <title xml:lang="eng">WFT-GTB: Integrating the Wurdboek fan ˈe Fryske Taal into the Geïntegreerde TaalBank</title>
             <publicationYear>2010</publicationYear>
-            <url>http://gtb.ivdnt.org/</url><CLARINCentre>Dutch Language Institute</CLARINCentre><OriginalSource>http://portal.clarin.nl/node/1919</OriginalSource>
+            <url>https://gtb.ivdnt.org/</url><CLARINCentre>Dutch Language Institute</CLARINCentre><OriginalSource>http://portal.clarin.nl/node/1919</OriginalSource>
             <ReleaseStatus>
                <LifeCycleStatus>published</LifeCycleStatus>
                <lastUpdate>2015-12-10</lastUpdate>
@@ -132,7 +132,7 @@
             <ResourceLicense>
                <license>unknown</license>
                <distributionType>public</distributionType>
-               <url>http://gtb.ivdnt.org/openlaszlo/my-apps/GTB/Productie/HuidigeVersie/src/inlgtb.html</url>
+               <url>https://gtb.ivdnt.org/openlaszlo/my-apps/GTB/Productie/HuidigeVersie/src/inlgtb.html</url>
                <Price>
                   <amount>0</amount>
                   <ISO4217>
@@ -144,16 +144,16 @@
               <Email>servicedesk@ivdnt.org</Email>
               <Organisation xml:lang="nld">Instituut voor de Nederlandse Taal</Organisation>
               <Organisation xml:lang="eng">Institute for the Dutch Language</Organisation>
-              <Url>http://www.ivdnt.org/</Url>
+              <Url>https://www.ivdnt.org/</Url>
             </Contact>
          </Access>
          <ResourceDocumentation>
             <Documentation>
-               <title>Frequently Asked Questions</title>
+               <title>Help</title>
                <documentationTarget>user</documentationTarget>
-               <url>http://gtb.ivdnt.org/openlaszlo/my-apps/GTB/Productie/HuidigeVersie/src/faq.html</url>
+               <url>https://gtb.ivdnt.org/</url>
                <ISO639>
-                  <iso-639-3-code>eng</iso-639-3-code>
+                  <iso-639-3-code>nld</iso-639-3-code>
                </ISO639>
             </Documentation>
 			<Publication><publicationCategory>in book</publicationCategory><publicationPurpose>scientific background</publicationPurpose><peerReviewStatus>yes</peerReviewStatus><Description><Description LanguageID="eng">Depuydt, K, de Does, J, Duijff, P and Sijens, H. 2017. Making the Dictionary of the Frisian Language Available in the Dutch Historical Dictionary Portal. In: Odijk, J and van Hessen, A. (eds.) CLARIN in the Low Countries, Pp. 151–165. London: Ubiquity Press. DOI: https://doi.org/10.5334/bbi.13. License: CC-BY 4.0</Description></Description></Publication><Pictures>
@@ -172,7 +172,7 @@
 		 <Email>servicedesk@ivdnt.org</Email>
 		 <Organisation xml:lang="nld">Instituut voor de Nederlandse Taal</Organisation>
 		 <Organisation xml:lang="eng">Institute for the Dutch Language</Organisation>
-		 <Url>http://www.ivdnt.org/</Url>
+		 <Url>https://www.ivdnt.org/</Url>
                </Contact>
                <Duration/>
             </Project>
@@ -189,7 +189,7 @@
                   <Email>katrien.depuydt@ivdnt.org</Email>
 		  <Organisation xml:lang="nld">Instituut voor de Nederlandse Taal</Organisation>
 		  <Organisation xml:lang="eng">Institute for the Dutch Language</Organisation>
-		  <Url>http://www.ivdnt.org/over-ons/contact/medewerkers</Url>
+		  <Url>https://www.ivdnt.org/over-ons/contact/medewerkers</Url>
                </Contact>
             </Creator>
          </SoftwareDevelopment>

--- a/legacy/cmdi/WNT.cmdi.xml
+++ b/legacy/cmdi/WNT.cmdi.xml
@@ -32,7 +32,7 @@
             <title xml:lang="nld">Woordenboek der Nederlandsche Taal</title>
             <title xml:lang="eng">Dictionary of the Dutch Language</title>
             <publicationYear>2007</publicationYear>
-            <url>http://gtb.ivdnt.org/</url><CLARINCentre>Dutch Language Institute</CLARINCentre>
+            <url>https://gtb.ivdnt.org/</url><CLARINCentre>Dutch Language Institute</CLARINCentre>
             <ReleaseStatus>
                <LifeCycleStatus>published</LifeCycleStatus>
                <lastUpdate>2015-12-10</lastUpdate>
@@ -122,7 +122,7 @@
                <license>unknown</license>
                <distributionType>academic</distributionType>
 	       <availability>free for academic use; non applicable for commercial parties</availability>
-               <url>http://gtb.ivdnt.org/openlaszlo/my-apps/GTB/Productie/HuidigeVersie/src/inlgtb.html</url>
+               <url>https://gtb.ivdnt.org/openlaszlo/my-apps/GTB/Productie/HuidigeVersie/src/inlgtb.html</url>
                <Price>
                   <amount>0</amount>
                   <ISO4217>
@@ -134,16 +134,16 @@
               <Email>servicedesk@ivdnt.org</Email>
               <Organisation xml:lang="nld">Instituut voor de Nederlandse Taal</Organisation>
               <Organisation xml:lang="eng">Institute for the Dutch Language</Organisation>
-              <Url>http://www.ivdnt.org/</Url>
+              <Url>https://www.ivdnt.org/</Url>
             </Contact>
          </Access>
          <ResourceDocumentation>
             <Documentation>
-               <title>Frequently Asked Questions</title>
+               <title>Help</title>
                <documentationTarget>user</documentationTarget>
-               <url>http://gtb.ivdnt.org/openlaszlo/my-apps/GTB/Productie/HuidigeVersie/src/faq.html</url>
+               <url>https://gtb.ivdnt.org/</url>
                <ISO639>
-                  <iso-639-3-code>eng</iso-639-3-code>
+                  <iso-639-3-code>nld</iso-639-3-code>
                </ISO639>
             </Documentation>
          </ResourceDocumentation>
@@ -152,12 +152,12 @@
                <name>GTB</name>
                <title>Geïntegreerde Taalbank Nederlands</title>
                <funder>IVDNT.ORG</funder>
-               <url>http://ivdnt.org</url>
+               <url>https://ivdnt.org</url>
                <Contact>
 		 <Email>servicedesk@ivdnt.org</Email>
 		 <Organisation xml:lang="nld">Instituut voor de Nederlandse Taal</Organisation>
 		 <Organisation xml:lang="eng">Institute for the Dutch Language</Organisation>
-		 <Url>http://www.ivdnt.org/</Url>
+		 <Url>https://www.ivdnt.org/</Url>
                </Contact>
                <Duration/>
             </Project>
@@ -167,7 +167,7 @@
                   <Email>katrien.depuydt@ivdnt.org</Email>
 		  <Organisation xml:lang="nld">Instituut voor de Nederlandse Taal</Organisation>
 		  <Organisation xml:lang="eng">Institute for the Dutch Language</Organisation>
-		  <Url>http://www.ivdnt.org/over-ons/contact/medewerkers</Url>
+		  <Url>https://www.ivdnt.org/over-ons/contact/medewerkers</Url>
                </Contact>
             </Creator>
          </SoftwareDevelopment>

--- a/legacy/cmdi/WebCelex.cmdi.xml
+++ b/legacy/cmdi/WebCelex.cmdi.xml
@@ -10,7 +10,7 @@
 	<ResourceProxyList>
 		<ResourceProxy id="WebCELEX001">
 			<ResourceType>Resource</ResourceType>
-			<ResourceRef>https://portal.clarin.inl.nl/webcelex/</ResourceRef>
+			<ResourceRef>https://portal.clarin.ivdnt.org/webcelex/</ResourceRef>
 		</ResourceProxy>
 	</ResourceProxyList>
       <JournalFileProxyList/>
@@ -22,7 +22,7 @@
             <name xml:lang="eng">WebCelex</name>
             <title xml:lang="eng">WebCelex</title>
             <publicationYear>2013</publicationYear>
-            <url>https://portal.clarin.inl.nl/webcelex/</url><CLARINCentre>Dutch Language Institute</CLARINCentre>
+            <url>https://portal.clarin.ivdnt.org/webcelex/</url><CLARINCentre>Dutch Language Institute</CLARINCentre>
             <ReleaseStatus>
                <LifeCycleStatus>published</LifeCycleStatus>
                <lastUpdate>0001-01-01</lastUpdate>
@@ -125,7 +125,7 @@
             </Output>
          </SoftwareImplementation>
          <Access>
-	   <catalogueLink>https://portal.clarin.inl.nl/webcelex/</catalogueLink>
+	   <catalogueLink>https://portal.clarin.ivdnt.org/webcelex/</catalogueLink>
             <ResourceLicense>
                <license>other</license>
                <distributionType>academic</distributionType>
@@ -142,14 +142,14 @@
               <Email>servicedesk@ivdnt.org</Email>
               <Organisation xml:lang="nld">Instituut voor de Nederlandse Taal</Organisation>
               <Organisation xml:lang="eng">Institute for the Dutch Language</Organisation>
-              <Url>http://www.ivdnt.org/</Url>
+              <Url>https://www.ivdnt.org/</Url>
             </Contact>
          </Access>
          <ResourceDocumentation>
             <Documentation>
                <title>WebCelex help facility</title>
                <documentationTarget>user</documentationTarget>
-               <url>https://portal.clarin.inl.nl/webcelex/scripts/help01.pl</url>
+               <url>https://portal.clarin.ivdnt.org/webcelex/scripts/help01.pl</url>
                <ISO639>
                   <iso-639-3-code>eng</iso-639-3-code>
                </ISO639>
@@ -173,7 +173,7 @@
                 <Email>carole.tiberius@ivdnt.org</Email>
 		<Organisation xml:lang="nld">Instituut voor de Nederlandse Taal</Organisation>
 		<Organisation xml:lang="eng">Institute for the Dutch Language</Organisation>
-		<Url>http://www.ivdnt.org/over-ons/contact/medewerkers</Url>
+		<Url>https://www.ivdnt.org/over-ons/contact/medewerkers</Url>
               </Contact>
             </Creator>
          </SoftwareDevelopment>

--- a/legacy/cmdi/autoSearch.cmdi.xml
+++ b/legacy/cmdi/autoSearch.cmdi.xml
@@ -94,12 +94,12 @@
             </Output>
          </SoftwareImplementation>
          <Access>
-	   <catalogueLink>https://portal.clarin.inl.nl</catalogueLink>
+	   <catalogueLink>https://portal.clarin.ivdnt.org</catalogueLink>
             <ResourceLicense>
                <license>other</license>
                <distributionType>academic</distributionType>
 	       <availability>Free, accessible through CLARIN Institutional login</availability>
-               <url>https://portal.clarin.inl.nl/autocorp/</url>
+               <url>https://portal.clarin.ivdnt.org/autocorp/</url>
                <Price>
                   <amount>0</amount>
                   <ISO4217>
@@ -111,14 +111,14 @@
               <Email>servicedesk@ivdnt.org</Email>
               <Organisation xml:lang="nld">Instituut voor de Nederlandse Taal</Organisation>
               <Organisation xml:lang="eng">Institute for the Dutch Language</Organisation>
-              <Url>http://www.ivdnt.org/</Url>
+              <Url>https://www.ivdnt.org/</Url>
             </Contact>
          </Access>
          <ResourceDocumentation>
             <Documentation>
                <title>AutoSearch demo: a brief overview</title>
                <documentationTarget>user</documentationTarget>
-               <url>https://portal.clarin.inl.nl/autocorp/doc/AutoSearch-manual.pdf</url>
+               <url>https://portal.clarin.ivdnt.org/autocorp/doc/AutoSearch-manual.pdf</url>
                <ISO639>
                   <iso-639-3-code>eng</iso-639-3-code>
                </ISO639>
@@ -146,7 +146,7 @@
                 <Email>servicedesk@ivdnt.org</Email>
                 <Organisation>Institute of Dutch Lexicology</Organisation>
                 <Organisation>Instituut voor Nederlandse Lexicology</Organisation>
-                <Url>http://www.ivdnt.org</Url>
+                <Url>https://www.ivdnt.org</Url>
               </Contact>
             </Creator>
          </SoftwareDevelopment>

--- a/source-registry/blacklab.yml
+++ b/source-registry/blacklab.yml
@@ -1,2 +1,2 @@
-source: https://github.com/INL/BlackLab
+source: https://github.com/instituutnederlandsetaal/BlackLab
 group: "Blacklab & Corpus Search"

--- a/source-registry/clariah-fcs-endpoints.yml
+++ b/source-registry/clariah-fcs-endpoints.yml
@@ -1,5 +1,5 @@
-source: https://github.com/INL/clariah-fcs-endpoints
+source: https://github.com/instituutnederlandsetaal/clariah-fcs-endpoints
 services:
-  - https://portal.clarin.inl.nl/fcscorpora/clariah-fcs-endpoints/sru
+  - https://portal.clarin.ivdnt.org/fcscorpora/clariah-fcs-endpoints/sru
 group: "Blacklab & Corpus Search"
 

--- a/source-registry/cobalt.yml
+++ b/source-registry/cobalt.yml
@@ -1,1 +1,1 @@
-source: https://github.com/INL/COBALT
+source: https://github.com/instituutnederlandsetaal/COBALT

--- a/source-registry/corpus-frontend.yml
+++ b/source-registry/corpus-frontend.yml
@@ -1,6 +1,6 @@
-source: https://github.com/INL/corpus-frontend
+source: https://github.com/instituutnederlandsetaal/corpus-frontend
 services:
-    - https://portal.clarin.inl.nl/autocorp/
+    - https://portal.clarin.ivdnt.org/autocorp/
       https://opensonar.ivdnt.org/
     - https://brievenalsbuit.ivdnt.org
     - https://chn.ivdnt.org/

--- a/source-registry/galahad-train-battery.yml
+++ b/source-registry/galahad-train-battery.yml
@@ -1,2 +1,2 @@
-source: https://github.com/INL/galahad-train-battery 
+source: https://github.com/instituutnederlandsetaal/galahad-train-battery 
 group: GaLAHaD

--- a/source-registry/galahad.yml
+++ b/source-registry/galahad.yml
@@ -1,4 +1,4 @@
-source: https://github.com/INL/galahad
+source: https://github.com/instituutnederlandsetaal/galahad
 group: GaLAHaD
 services:
   - https://portal.clarin.ivdnt.org/galahad

--- a/source-registry/int-pie.yml
+++ b/source-registry/int-pie.yml
@@ -1,2 +1,2 @@
-source: https://github.com/INL/int-pie
+source: https://github.com/instituutnederlandsetaal/int-pie
 group: GaLAHaD


### PR DESCRIPTION
Our GitHub organisation was renamed from INL to instituutnederlandsetaal recently. This updates the repository links accordingly.

Also converted old links from .inl.nl to .ivdnt.org and http:// to https:// in many places, or replaced old or broken (documentation) links.