### PR TITLE
Removing all references to DANE

### DIFF
--- a/source-registry/dane-asr-worker.yml
+++ b/source-registry/dane-asr-worker.yml
@@ -1,2 +1,0 @@
-source: https://github.com/CLARIAH/dane-asr-worker
-group: DANE

--- a/source-registry/dane-download-worker.yml
+++ b/source-registry/dane-download-worker.yml
@@ -1,2 +1,0 @@
-source: https://github.com/CLARIAH/dane-download-worker
-group: DANE

--- a/source-registry/dane-object-classification-worker
+++ b/source-registry/dane-object-classification-worker
@@ -1,2 +1,0 @@
-source: https://github.com/CLARIAH/dane-object-classification-worker
-group: DANE

--- a/source-registry/dane-server.yml
+++ b/source-registry/dane-server.yml
@@ -1,2 +1,0 @@
-source: https://github.com/CLARIAH/DANE-server
-group: DANE

--- a/source-registry/dane-workflows.yml
+++ b/source-registry/dane-workflows.yml
@@ -1,2 +1,0 @@
-source: https://github.com/beeldengeluid/dane-workflows
-group: DANE

--- a/source-registry/dane.yml
+++ b/source-registry/dane.yml
@@ -1,2 +1,0 @@
-source: https://github.com/CLARIAH/DANE
-group: DANE


### PR DESCRIPTION
Removing DANE, because it is flawed and not to be recommended. 

The biggest flaw is having both a RabbitMQ state and an Elasticsearch state, which can easily get out of sync, making it really hard to debug/monitor things properly.

